### PR TITLE
Creative Commons Zero의 SPDX 표현을 바르게 고침

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "git+https://github.com/perillamint/peaceful_twitter_regex.git"
   },
   "author": "perillamint",
-  "license": "CC-0",
+  "license": "CC0-1.0",
   "bugs": {
     "url": "https://github.com/perillamint/peaceful_twitter_regex/issues"
   },


### PR DESCRIPTION
Creative Commons Zero의 SPDX 표현은 `CC0-1.0`입니다. yarn이 불평하더라고요.